### PR TITLE
Uppy Restrictions

### DIFF
--- a/GPS.html
+++ b/GPS.html
@@ -168,7 +168,18 @@
     <script src="https://transloadit.edgly.net/releases/uppy/v0.25.5/dist/uppy.min.js"></script>
     <script>
       
-      const uppy = Uppy.Core({debug: true, autoProceed: false})
+      const uppy = Uppy.Core({
+        debug: true,
+        autoProceed: false,
+        id: 'uppy',
+        restrictions: {
+          maxFileSize: 1000000,
+          maxNumberOfFiles: 1,
+          minNumberOfFiles: 1
+          
+        },
+          
+         })
         .use(Uppy.Dashboard, {
           trigger: '#uppyModalOpener' })
         .use(Uppy.Webcam, {target: Uppy.Dashboard})


### PR DESCRIPTION
Implemented uppy restrictions of file size, maximum and minimum number of files required to upload. Currently the upload is still going to the test servers of Uppy but will be redirected to my AWS S3 bucket shortly 